### PR TITLE
Fix default greeting text and tests

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -16,7 +16,7 @@ describe('AppController', () => {
 
   describe('root', () => {
     it('should return "ai service started"', () => {
-      expect(appController.getHello()).toBe('ai service  started');
+      expect(appController.getHello()).toBe('ai service started');
     });
   });
 });

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from '@nestjs/common';
 @Injectable()
 export class AppService {
   getHello(): string {
-    return 'ai service  started';
+    return 'ai service started';
   }
 }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -20,6 +20,6 @@ describe('AppController (e2e)', () => {
     return request(app.getHttpServer())
       .get('/')
       .expect(200)
-      .expect('Hello World!');
+      .expect('ai service started');
   });
 });


### PR DESCRIPTION
## Summary
- ensure greeting message uses a single space
- update unit and e2e tests to match the new message

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684057a18f608323936640534b1e2229